### PR TITLE
Update prisma.yml

### DIFF
--- a/prisma/prisma.yml
+++ b/prisma/prisma.yml
@@ -10,11 +10,6 @@ generate:
   - generator: typescript-client
     output: ../src/generated/prisma-client/
 
-# Ensures Prisma client is re-generated after a datamodel change.
-hooks:
-  post-deploy:
-    - prisma generate
-
 # Seeds initial data into the database by running a script.
 seed:
   import: seed.graphql


### PR DESCRIPTION
We don't need to generate throught hook since Prisma 1.31. 

```Warning: The `prisma generate` command was executed twice. Since Prisma 1.31, the Prisma client is generated automatically after running `prisma deploy`. It is not necessary to generate it via a `post-deploy` hook any more, you can therefore remove the hook if you do not need it otherwise.```